### PR TITLE
Parse the GA urls returned as nextLink on response

### DIFF
--- a/gapy/response.py
+++ b/gapy/response.py
@@ -2,6 +2,14 @@ from datetime import datetime
 import urlparse
 
 
+def parse_ga_url(url):
+    escape_semicolons = url.replace(";", "%3B")
+    query = urlparse.parse_qsl(
+        urlparse.urlparse(escape_semicolons).query)
+    return dict(
+        (key.replace("-", "_"), values) for key, values in query)
+
+
 class BaseResponse(object):
     def __init__(self, response):
         self._response = response
@@ -47,11 +55,7 @@ class QueryResponse(BaseResponse):
                     self._add_datetime(result["dimensions"])
                 yield result
             if self._response.get("nextLink"):
-                next_query = urlparse.parse_qsl(
-                    urlparse.urlparse(self._response["nextLink"]).query)
-                next_kwargs = dict(
-                    (key.replace("-", "_"), values) for key, values in
-                    next_query)
+                next_kwargs = parse_ga_url(self._response.get("nextLink"))
                 self._response = self._service.get_raw_response(**next_kwargs)
             else:
                 break

--- a/gapy_test.py
+++ b/gapy_test.py
@@ -7,6 +7,7 @@ from mock import patch, ANY, Mock, call
 from gapy.error import GapyError
 from gapy.client import ManagementClient, QueryClient, Client, \
     from_private_key, from_secrets_file
+from gapy.response import parse_ga_url
 
 
 def fixture(name):
@@ -267,6 +268,16 @@ class QueryClientTest(unittest.TestCase):
             ids='ga:12345', end_date='2012-01-15', start_date='2012-01-10',
             start_index="1001", max_results="1000"
         ))
+
+
+class ParseGAUrlTest(unittest.TestCase):
+    def test_url_with_semicolon(self):
+        next_kwargs = parse_ga_url(
+            "https://www.googleapis.com/analytics/v3/data/ga?ids=ga:53872948&dimensions=ga:pageTitle,ga:pagePath,ga:day,ga:month,ga:year&metrics=ga:pageviews&filters=ga:pagePath!~%5E(/$%7C/(.*-finished$%7C%5C?backtoPage%7Ctransformation%7Cservice-manual%7Cperformance%7Cgovernment%7Csearch%7Cdone%7Cprint).*);ga:pageTitle!~(404%7C410%7C500%7C504%7C510%7CAn+error+has+occurred)&start-date=2014-02-10&end-date=2014-02-23&start-index=1001&max-results=1000")
+
+        self.assertEqual(
+            next_kwargs['filters'],
+            "ga:pagePath!~^(/$|/(.*-finished$|\\?backtoPage|transformation|service-manual|performance|government|search|done|print).*);ga:pageTitle!~(404|410|500|504|510|An error has occurred)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When GA returns filters that use an AND (represented as a semicolon) it
does not escape it as %3B. This does not agree with urlparse, as it is
by the book. In order to not strip AND filters we should make sure all
the semicolons are escaped before parsing the url.
