### PR TITLE
Add management.segments API call

### DIFF
--- a/fixtures/segments.json
+++ b/fixtures/segments.json
@@ -1,0 +1,27 @@
+{
+      "username": "673591833363@developer.gserviceaccount.com",
+      "kind": "analytics#segments",
+      "items": [
+        {
+            "definition": "ga:visitorType==New Visitor",
+            "kind": "analytics#segment", 
+            "segmentId": "gaid::-2", 
+            "type": "BUILT_IN", 
+            "id": "-2", 
+            "selfLink": "https://www.googleapis.com/analytics/v3/management/segments/gaid::-2",
+            "name": "New Visitors" 
+        },
+        {
+            "definition": "ga:visitorType==Returning Visitor",
+            "kind": "analytics#segment", 
+            "segmentId": "gaid::-3", 
+            "type": "BUILT_IN", 
+            "id": "-3", 
+            "selfLink": "https://www.googleapis.com/analytics/v3/management/segments/gaid::-3",
+            "name": "Returning Visitors"
+        }
+      ],
+      "itemsPerPage": 1000,
+      "startIndex": 1,
+      "totalResults": 1
+}

--- a/gapy/client.py
+++ b/gapy/client.py
@@ -126,6 +126,9 @@ class ManagementClient(object):
     def profile(self, account, webproperty, id):
         return self._item(self.profiles(account, webproperty), id)
 
+    def segments(self):
+        return self._list("segments")
+
     def _list(self, name, **kwargs):
         return ManagementResponse(
             getattr(self._service.management(), name)().list(

--- a/gapy_test.py
+++ b/gapy_test.py
@@ -145,6 +145,19 @@ class ManagementClientTest(unittest.TestCase):
             self.client.profile,
             "26179049", "UA-26179049-2", "53872949")
 
+    def test_segments(self):
+        self.mock_list("segments")
+
+        segments = self.client.segments()
+
+        self.assert_list_called("segments")
+        self.assertEqual(segments.username,
+                         "673591833363@developer.gserviceaccount.com")
+        self.assertEqual(segments.kind, "analytics#segments")
+
+        segment = iter(segments).next()
+        self.assertEqual(segment["id"], "-2")
+
 
 class QueryClientTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This makes `client.management.segments()` work. It returns the list of segments available.

It's this API call:
https://developers.google.com/resources/api-libraries/documentation/analytics/v3/python/latest/analytics_v3.management.segments.html
