### PR TITLE
Add http_client arg to from_private_key and from_secrets_file

### DIFF
--- a/gapy/client.py
+++ b/gapy/client.py
@@ -23,7 +23,7 @@ def _get_storage(storage, storage_path):
 
 def from_private_key(account_name, private_key=None, private_key_path=None,
                      storage=None, storage_path=None, api_version="v3",
-                     readonly=False):
+                     readonly=False, http_client=None):
     """Create a client for a service account.
 
     Create a client with an account name and a private key.
@@ -53,11 +53,11 @@ def from_private_key(account_name, private_key=None, private_key_path=None,
                                                 scope)
     credentials.set_store(storage)
 
-    return Client(_build(credentials, api_version))
+    return Client(_build(credentials, api_version, http_client))
 
 
 def from_secrets_file(client_secrets, storage=None, storage_path=None,
-                      api_version="v3", readonly=False):
+                      api_version="v3", readonly=False, http_client=None):
     """Create a client for a web or installed application.
 
     Create a client with a client secrets file.
@@ -79,15 +79,17 @@ def from_secrets_file(client_secrets, storage=None, storage_path=None,
     if credentials is None or credentials.invalid:
         credentials = run(flow, storage)
 
-    return Client(_build(credentials, api_version))
+    return Client(_build(credentials, api_version, http_client))
 
 
-def _build(credentials, api_version):
+def _build(credentials, api_version, http_client=None):
     """Build the client object."""
-    http = httplib2.Http()
-    http = credentials.authorize(http)
+    if not http_client:
+        http_client = httplib2.Http()
 
-    return build("analytics", api_version, http=http)
+    authorised_client = credentials.authorize(http_client)
+
+    return build("analytics", api_version, http=authorised_client)
 
 
 class Client(object):

--- a/gapy_test.py
+++ b/gapy_test.py
@@ -34,7 +34,7 @@ class GapyTest(unittest.TestCase):
         client = from_private_key(
             "account_name", "private_key",
             storage_path="/tmp/foo.dat")
-        build.assert_called_with(ANY, ANY)
+        build.assert_called_with(ANY, ANY, None)
         self.assertTrue(isinstance(client, Client))
 
     def test_client_from_secrets_file_fails_with_no_secrets_file(self):


### PR DESCRIPTION
These functions now take an optional http_client argument which is passed on
to build() from apiclient.discovery. This is so that extra functionality (such
as exponential backoff) can be added easily.
