### PR TITLE
Get creds from db

### DIFF
--- a/gapy/__init__.py
+++ b/gapy/__init__.py
@@ -1,3 +1,3 @@
 __title__ = "gapy"
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __author__ = "Rob Young"

--- a/gapy_test.py
+++ b/gapy_test.py
@@ -7,7 +7,7 @@ from oauth2client.clientsecrets import InvalidClientSecretsError
 from mock import patch, ANY, Mock, call
 from gapy.error import GapyError
 from gapy.client import ManagementClient, QueryClient, Client, \
-    from_private_key, from_secrets_file
+    from_private_key, from_secrets_file, from_credentials_db
 from gapy.response import parse_ga_url
 
 


### PR DESCRIPTION
Introduces the ability to pass client secrets and OAuth 2.0 credentials as objects rather than paths to files. This is in support of the story to expose an endpoint in Stagecraft for the execution of collectors (https://www.pivotaltracker.com/story/show/100638120) which includes the storage of client secrets and credentials in the Stagecraft DB.