### PR TITLE
Bump version

### DIFF
--- a/gapy/__init__.py
+++ b/gapy/__init__.py
@@ -1,3 +1,3 @@
 __title__ = "gapy"
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __author__ = "Rob Young"


### PR DESCRIPTION
Pull request https://github.com/alphagov/stagecraft/pull/426
is failing to build due to performance platform-collector 0.2.2
not recognising the latest version of the gapy client (1.3.1) so
bumping this repo, performanceplatform-collector and stagecraft
in an attempt to resolve this.