### PR TITLE
Fix call to run flow

### DIFF
--- a/gapy/__init__.py
+++ b/gapy/__init__.py
@@ -1,3 +1,3 @@
 __title__ = "gapy"
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 __author__ = "Rob Young"

--- a/gapy/client.py
+++ b/gapy/client.py
@@ -1,7 +1,6 @@
 from apiclient.discovery import build
 import httplib2
-from oauth2client.client import SignedJwtAssertionCredentials, flow_from_clientsecrets, \
-    OAuth2WebServerFlow
+from oauth2client.client import SignedJwtAssertionCredentials, flow_from_clientsecrets
 from oauth2client.file import Storage
 from oauth2client.tools import run_flow
 
@@ -107,20 +106,7 @@ def from_credentials_db(client_secrets, storage, api_version="v3",
       ga_hook: function, a hook that is called every time a query is made
                against GA.
     """
-    scope = GOOGLE_API_SCOPE_READONLY if readonly else GOOGLE_API_SCOPE
-    flow = OAuth2WebServerFlow(
-        client_secrets.get('client_id'),
-        client_secrets.get('client_secret'),
-        scope,
-        redirect_uri=client_secrets.get('redirect_uri'),
-        user_agent=client_secrets.get('user_agent', None),
-        auth_uri=client_secrets.get('auth_uri'),
-        token_uri=client_secrets.get('token_uri'))
-
     credentials = storage.get()
-
-    if credentials is None or credentials.invalid:
-        credentials = run_flow(flow, storage)
 
     return Client(_build(credentials, api_version, http_client), ga_hook)
 

--- a/gapy/client.py
+++ b/gapy/client.py
@@ -60,9 +60,9 @@ def from_private_key(account_name, private_key=None, private_key_path=None,
     return Client(_build(credentials, api_version, http_client), ga_hook)
 
 
-def from_secrets_file(client_secrets, storage=None, storage_path=None,
-                      api_version="v3", readonly=False, http_client=None,
-                      ga_hook=None):
+def from_secrets_file(client_secrets, storage=None, flags=None,
+                      storage_path=None, api_version="v3", readonly=False,
+                      http_client=None, ga_hook=None):
     """Create a client for a web or installed application.
 
     Create a client with a client secrets file.
@@ -85,7 +85,7 @@ def from_secrets_file(client_secrets, storage=None, storage_path=None,
     storage = _get_storage(storage, storage_path)
     credentials = storage.get()
     if credentials is None or credentials.invalid:
-        credentials = run_flow(flow, storage)
+        credentials = run_flow(flow, storage, flags)
 
     return Client(_build(credentials, api_version, http_client), ga_hook)
 


### PR DESCRIPTION
Add the missing mandatory 3rd argument to the call of the run_flow method of Google's oauth2client library.

Remove the redundant credentials generation code from the from_credentials_db method, as credentials argument should always be passed to this method.

