### PR TITLE
Pin oauth2client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: python
 python:
   - "2.6"
   - "2.7"
-install: "pip install -r requirements.txt --use-mirrors"
+install: "pip install -r requirements.txt"
 script: nosetests --with-doctest

--- a/gapy/__init__.py
+++ b/gapy/__init__.py
@@ -1,3 +1,3 @@
 __title__ = "gapy"
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 __author__ = "Rob Young"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+oauth2client==1.5.2
 google-api-python-client==1.4.2
 mock==1.0.1
 nose==1.2.1


### PR DESCRIPTION
SignedJwtAssertionCredentials function has been removed in oauth2client so pinning the version
required. oauth2client is required by google-api-python-client.